### PR TITLE
Fixed JSON.stringify issue with props, caused by webpackStats, with CircularJSON

### DIFF
--- a/components/Root.jsx
+++ b/components/Root.jsx
@@ -1,8 +1,9 @@
 
-import React  from 'react'
-import Router from 'react-router'
-import Header from './Header.jsx'
-import css    from '../css/base.css'
+import React        from 'react'
+import Router       from 'react-router'
+import CircularJSON from 'circular-json'
+import Header       from './Header.jsx'
+import css          from '../css/base.css'
 
 let RouteHandler = Router.RouteHandler
 
@@ -40,5 +41,5 @@ export default class Root extends React.Component {
 }
 
 function safeStringify (obj) {
-  return JSON.stringify(obj).replace(/<\/script/g, '<\\/script').replace(/<!--/g, '<\\!--')
+  return CircularJSON.stringify(obj).replace(/<\/script/g, '<\\/script').replace(/<!--/g, '<\\!--')
 }

--- a/entry.js
+++ b/entry.js
@@ -1,10 +1,11 @@
 
-import React from 'react'
-import Router from 'react-router'
-import Routes from './Routes.jsx'
+import React        from 'react'
+import Router       from 'react-router'
+import CircularJSON from 'circular-json'
+import Routes       from './Routes.jsx'
 
 if (typeof document !== 'undefined') {
-  var initialProps = JSON.parse(document.getElementById('initial-props').innerHTML)
+  var initialProps = CircularJSON.parse(document.getElementById('initial-props').innerHTML)
   Router.run(Routes, Router.HistoryLocation, function (Handler) {
     React.render(React.createElement(Handler, initialProps), document)
   })

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-core": "^5.6.15",
     "babel-loader": "^5.2.2",
     "basscss": "^6.1.6",
+    "circular-json": "^0.3.0",
     "css-loader": "^0.14.4",
     "cssnext": "^1.6.0",
     "cssnext-loader": "^1.0.1",


### PR DESCRIPTION
If you do a fresh install of your boilerplate, and then try to run `npm start`, you'll get an error for trying to apply `JSON.stringify` to `this.props`, because `this.props` has circular references.

The source of these circular references seems to be the property **webpackStats**, which is injected by _static-site-generator-webpack-plugin_.

This issue actually also occurred upstream and was fixed after your fork: https://github.com/jxnblk/react-static-site-boilerplate/issues/9

I'm however not satisfied with @jxnblk's solution; **webpackStats** was introduced by version 1.2.0 of _static-site-generator-webpack-plugin_, so he elected to specify version 1.1.2 of the plugin in **package.json**.

I've opted instead to use [CircularJSON](https://github.com/WebReflection/circular-json) to address this problem.
